### PR TITLE
fastd peer GWs entfernt.Fehlerquelle

### DIFF
--- a/backbone/gw-commander1024
+++ b/backbone/gw-commander1024
@@ -1,4 +1,0 @@
-#gw-commander1024
-key "9bf14cf6faa8bc0bc87e45b109f065339551cf4ab63a668c1a90897f05eceb36";
-remote ipv4 "commander1024.gw.freifunk-muenster.de" port 14242;
-remote ipv6 "commander1024.gw.freifunk-muenster.de" port 14242;

--- a/backbone/gw-fanlin
+++ b/backbone/gw-fanlin
@@ -1,4 +1,0 @@
-#gw-fanlin
-key "346234ecf552727233b406131c214b5b58ceb4b72b9503276aff419a02fc3137";
-remote ipv4 "fanlin.gw.freifunk-muenster.de" port 14242;
-remote ipv6 "fanlin.gw.freifunk-muenster.de" port 14242;

--- a/backbone/gw-fusselkater
+++ b/backbone/gw-fusselkater
@@ -1,4 +1,0 @@
-#gw-fusselkater
-key "071576a93dd3e7dcdd6e566024879dd01a118cddbc4258247dd825ad42351394";
-remote ipv4 "fusselkater.gw.freifunk-muenster.de" port 14242;
-remote ipv6 "fusselkater.gw.freifunk-muenster.de" port 14242;


### PR DESCRIPTION
Wenn die Einträge nicht lokal entfernt werden bzw jemand aus versehen
das GW Skript zu ordentlich durcharbeitet erhält man eine SN die neben
GRETAP auch noch fastd tunnel zu den GW erhält. Also besser entfernen
da nicht mehr benötigt.
